### PR TITLE
fix build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"paths": {
 			"angular-sdk": ["dist/angular-sdk"]
 		},
+    "typeRoots": ["./node_modules/@types", "./node_modules/@descope"],
 		"baseUrl": "./",
 		"outDir": "./dist/out-tsc",
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
fixes https://github.com/descope-dev/angular-sdk/issues/17

The typeRoots option in the tsconfig.json file specifies the directories where TypeScript should look for type declarations when resolving types

By adding `./node_modules/@descope` to the typeRoots array (along with the default), TS compiler knows to find internal packages d.ts files

though this is probably not the ideal solution, it works that way on other Descope internal packages

@MF57 fyi 