### PR TITLE
Override web component sdk configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.5.0-alpha.2",
 			"license": "MIT",
 			"dependencies": {
-				"@descope/web-component": "3.4.3",
+				"@descope/web-component": "3.7.6",
 				"tslib": "^2.3.0"
 			},
 			"devDependencies": {
@@ -2529,29 +2529,29 @@
 			}
 		},
 		"node_modules/@descope/core-js-sdk": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.5.1.tgz",
-			"integrity": "sha512-fpTmCVS3fOpYOWBt/5xJ1h8B4edu5mHwpsBzuJgmeW+4BqYK9dzwSCZia+vPAbNIbFBL18ar1yILMIeARNw4EA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+			"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 			"dependencies": {
 				"jwt-decode": "3.1.2",
 				"lodash.get": "4.4.2"
 			}
 		},
 		"node_modules/@descope/web-component": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.4.3.tgz",
-			"integrity": "sha512-GefzDUk/+l6eEdn4GkhCnNMnCOUMEZLMlAHD/B4zE2IOjMPbVpgNmmHtsq7FfpQKhAlmZ9OQYOyJnUOcXiP+Eg==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"dependencies": {
-				"@descope/web-js-sdk": "1.8.3",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			}
 		},
 		"node_modules/@descope/web-js-sdk": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.8.3.tgz",
-			"integrity": "sha512-xSYIg6bZ3EHJ0MPaf6G5ixKR9GCYnI9vQlnximnegs/eJNgIljbi/1mp3qKX0TiTzXXyow63vPdcONbHzTD/wQ==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+			"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 			"dependencies": {
-				"@descope/core-js-sdk": "2.5.1",
+				"@descope/core-js-sdk": "2.9.1",
 				"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 				"js-cookie": "3.0.5",
 				"tslib": "2.6.2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		]
 	},
 	"dependencies": {
-		"@descope/web-component": "3.4.3",
+		"@descope/web-component": "3.7.6",
 		"tslib": "^2.3.0"
 	},
 	"optionalDependencies": {

--- a/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { default as DescopeWC } from '@descope/web-component';
 import { DescopeComponent } from './descope.component';
 import createSdk from '@descope/web-js-sdk';
 import { DescopeAuthConfig } from '../../types/types';
@@ -66,6 +66,15 @@ describe('DescopeComponent', () => {
 		const html: HTMLElement = fixture.nativeElement;
 		const webComponentHtml = html.querySelector('descope-wc');
 		expect(webComponentHtml).toBeDefined();
+
+		expect(DescopeWC.sdkConfigOverrides).toEqual({
+			baseHeaders: {
+				'x-descope-sdk-name': 'angular',
+				'x-descope-sdk-version': '0.0.0'
+			},
+			persistTokens: false,
+			hooks: {}
+		});
 	});
 
 	it('should correctly setup attributes based on inputs', () => {

--- a/projects/angular-sdk/src/lib/components/descope/descope.component.ts
+++ b/projects/angular-sdk/src/lib/components/descope/descope.component.ts
@@ -52,7 +52,27 @@ export class DescopeComponent implements OnInit, OnChanges {
 	}
 
 	ngOnInit() {
-		DescopeWc.sdkConfigOverrides = { baseHeaders };
+		const sdk = this.authService.descopeSdk; // Capture the class context in a variable
+		DescopeWc.sdkConfigOverrides = {
+			// Overrides the web-component's base headers to indicate usage via the React SDK
+			baseHeaders,
+			// Disables token persistence within the web-component to delegate token management
+			// to the global SDK hooks. This ensures token handling aligns with the SDK's configuration,
+			// and web-component requests leverage the global SDK's beforeRequest hooks for consistency
+			persistTokens: false,
+			hooks: {
+				get beforeRequest() {
+					// Retrieves the beforeRequest hook from the global SDK, which is initialized
+					// within the AuthProvider using the desired configuration. This approach ensures
+					// the web-component utilizes the same beforeRequest hooks as the global SDK
+					return sdk.httpClient.hooks?.beforeRequest;
+				},
+				set beforeRequest(_) {
+					// The empty setter prevents runtime errors when attempts are made to assign a value to 'beforeRequest'.
+					// JavaScript objects default to having both getters and setters
+				}
+			}
+		};
 		this.setupWebComponent();
 		this.elementRef.nativeElement.appendChild(this.webComponent);
 	}

--- a/projects/demo-app/src/app/app.module.ts
+++ b/projects/demo-app/src/app/app.module.ts
@@ -35,7 +35,7 @@ export function initializeApp(authService: DescopeAuthService) {
 		DescopeAuthModule.forRoot({
 			projectId: environment.descopeProjectId,
 			baseUrl: environment.descopeBaseUrl || '',
-			sessionTokenViaCookie: false
+			sessionTokenViaCookie: true
 		})
 	],
 	providers: [


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/5319

## Related PRs

https://github.com/descope/descope-js/pull/356


## Description
Override web component sdk configs so that the hooks running before will run in the same manner

same as https://github.com/descope/react-sdk/pull/456